### PR TITLE
Fix StringIndexError on CRLF + multibyte source in HTML coverage report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This file contains the changelog for the ExtendedLocalCoverage package. It follo
 
 ## Unreleased
 
+## [0.2.1] - 2026-06-23
+
+### Fixed
+- Fixed a `StringIndexError` in the HTML line-coverage report (`highlighted_lines`, `JuliaSyntaxHighlighting` extension) when a source file used CRLF line endings and had a multibyte Unicode character (e.g. `π`) right before the `\r`. The trailing `\r` is now stripped with `chop` instead of byte-based indexing.
+
+## [0.2.0] - 2026-01-05
+
+### Added
+- The HTML coverage report is now generated natively in Julia (via `HypertextTemplates`) as a self-contained static page, replacing the previous report based on the Python `pycobertura` package.
+- Optional Julia syntax highlighting of the source code in the HTML report through a `JuliaSyntaxHighlighting` package extension (with a `StyledStrings` extension for rendering), available on Julia 1.12+.
+
+### Removed
+- Dropped the `PythonCall` and `CondaPkg` dependencies (no Python/Conda environment is needed anymore).
+- Removed the `WrappedPackageCoverage` `show` wrapper and the `PrettyTables` dependency, as the upstream `PrettyTables` v3 issue was fixed.
+
 ## [0.1.3] - 2025-09-29
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExtendedLocalCoverage"
 uuid = "eb248270-a497-541c-8f75-6bb2aa2715dc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -29,3 +29,6 @@ Revise = "3.7.1"
 StyledStrings = "1.11.0"
 TOML = "1.0.3"
 julia = "1.10"
+
+[workspace]
+projects = ["test", "docs"]

--- a/ext/JuliaSyntaxHighlightingExt.jl
+++ b/ext/JuliaSyntaxHighlightingExt.jl
@@ -6,7 +6,7 @@ module JuliaSyntaxHighlightingExt
     function ExtendedLocalCoverage.highlighted_lines(io::IO)
         highlighted = highlight(io)
         map(eachsplit(highlighted, '\n')) do line
-            endswith(line, '\r') ? line[1:end-1] : line # Deal with Windows line endings
+            endswith(line, '\r') ? chop(line) : line # Deal with Windows line endings (chop is char-safe, unlike byte indexing)
         end
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,8 @@
 [deps]
+ExtendedLocalCoverage = "eb248270-a497-541c-8f75-6bb2aa2715dc"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[sources]
+ExtendedLocalCoverage = {path = ".."}

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -77,6 +77,21 @@
     end
 end
 
+@testitem "highlighted_lines CRLF + multibyte" begin
+    # Regression: CRLF line endings with a multibyte char (e.g. π) right before
+    # the \r used to throw StringIndexError because the old code stripped the \r
+    # with byte arithmetic (line[1:end-1]) instead of a char-safe chop.
+    # On Julia 1.12+ JuliaSyntaxHighlighting is preloaded, so its extension is
+    # active and ExtendedLocalCoverage.highlighted_lines is defined (same
+    # assumption as the "html defaults functions" testitem below).
+    @static if VERSION >= v"1.12"
+        @assert ExtendedLocalCoverage.JuliaSyntaxHighlightingLoaded[] "JuliaSyntaxHighlighting extension not loaded"
+        lines = ExtendedLocalCoverage.highlighted_lines(IOBuffer("x = 2π\r\nb = 1\r\n"))
+        @test String(lines[1]) == "x = 2π"  # no trailing \r, no StringIndexError
+        @test String(lines[2]) == "b = 1"
+    end
+end
+
 @testitem "html defaults functions" begin
     using ExtendedLocalCoverage: default_lines_function, default_html_function
 


### PR DESCRIPTION
## Summary

Fixes a `StringIndexError` that crashed the HTML line-coverage report when a covered source file had **CRLF line endings** and a **multibyte Unicode char** (e.g. `π`, `°`) immediately before the `\r`.

The `JuliaSyntaxHighlighting` extension stripped the trailing `\r` with `line[1:end-1]` — byte arithmetic. When the preceding char was multibyte, `end-1` landed inside it and threw. Replaced with the char-safe `chop`.

Minimal reproducer (pure Base):
```julia
"x = 2π\r"[1:end-1]   # ERROR: StringIndexError: invalid index [7]
```

## Changes (per commit)
1. **Migrate test and docs to a Pkg workspace** — single root manifest covers package + test + docs.
2. **Fix `StringIndexError`** — `chop` instead of byte indexing, plus a regression test feeding CRLF + multibyte input through `highlighted_lines` (guarded to Julia 1.12+ where the extension is available).
3. **Release 0.2.1** — version bump + CHANGELOG entry, and backfill of the missing 0.2.0 entry.

## Verification
Relying on PR CI (Julia 1 + 1.10).