### PR TITLE
Add julia_args kwarg + heap-size-hint env var to generate_package_coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file contains the changelog for the ExtendedLocalCoverage package. It follo
 
 ## Unreleased
 
+## [0.2.2] - 2026-06-23
+
+### Added
+- `generate_package_coverage` now accepts a `julia_args` keyword (a vector of strings, like `test_args`) that is forwarded to the julia process `Pkg.test` spawns for the test run. The main use case is `julia_args = ["--heap-size-hint=6G"]` to bound the test process' GC heap on memory-limited CI runners and avoid OOM kills. `LocalCoverage.generate_coverage` does not forward `julia_args`, so the test run is now driven via `Pkg.test` directly.
+- The `EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` environment variable, when set (e.g. `6G`), adds `--heap-size-hint=<value>` to the test process' `julia_args`, making the hint configurable from CI without changing the call site. An explicit `--heap-size-hint` in `julia_args` takes precedence.
+
 ## [0.2.1] - 2026-06-23
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "eb248270-a497-541c-8f75-6bb2aa2715dc"
 version = "0.2.1"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
 
+[workspace]
+projects = ["test", "docs"]
+
 [deps]
 CoverageTools = "c36e975a-824b-4404-a568-ef97ca766997"
 HypertextTemplates = "c7d46f9d-34c3-4420-bf57-257f25aec718"
@@ -12,6 +15,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [weakdeps]
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 JuliaSyntaxHighlighting = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
 StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
@@ -28,7 +32,5 @@ Pkg = "1"
 Revise = "3.7.1"
 StyledStrings = "1.11.0"
 TOML = "1.0.3"
+Tables = "1.12.1"
 julia = "1.10"
-
-[workspace]
-projects = ["test", "docs"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExtendedLocalCoverage"
 uuid = "eb248270-a497-541c-8f75-6bb2aa2715dc"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,29 @@ using ExtendedLocalCoverage
 cov_data = generate_package_coverage();
 ```
 
+### Limiting test-process memory on CI
+
+The coverage test run happens in a separate julia process spawned by `Pkg.test`. On
+memory-limited CI runners (e.g. an 8 GB container) this can get OOM-killed, because julia
+sizes its GC heap target to the *host* RAM rather than the cgroup limit. Pass
+`--heap-size-hint` to that process via the `julia_args` keyword (a vector of strings, like
+`test_args`):
+
+```julia
+generate_package_coverage(; julia_args = ["--heap-size-hint=6G"])
+```
+
+For CI configs it is often easier to set this without touching the call site, via the
+`EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` environment variable:
+
+```bash
+EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT=6G   # adds --heap-size-hint=6G to the test process
+```
+
+An explicit `--heap-size-hint` in `julia_args` takes precedence over the environment
+variable. (Note the `JULIA_HEAP_SIZE_HINT` env var does *not* work — only the
+`--heap-size-hint` CLI flag sets the test process' heap-size hint.)
+
 See the [developer documentation](https://disberd.github.io/ExtendedLocalCoverage.jl/dev) for more details.
 
 ## How to Cite

--- a/src/ExtendedLocalCoverage.jl
+++ b/src/ExtendedLocalCoverage.jl
@@ -80,8 +80,7 @@ This acts similary to (and based on) the `generate_coverage` function from [Loca
 - `test_args = [""]` this is passed on to `Pkg.test` (it becomes `ARGS` in the test process).
 
 - `julia_args = String[]` is a vector of extra command-line flags (strings, like `test_args`) forwarded to the julia process that `Pkg.test` spawns for the test run. The main use case is passing `--heap-size-hint` to bound the test process' GC heap on memory-limited CI runners (where julia otherwise sizes its heap to the host RAM, not the cgroup limit, and can get OOM-killed). For example `julia_args = ["--heap-size-hint=6G"]`. Note `LocalCoverage.generate_coverage` does not forward `julia_args`, which is why this package runs `Pkg.test` directly.
-
-- The `EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` environment variable, when set to a non-empty value (e.g. `6G`), adds `--heap-size-hint=<value>` to the test process' `julia_args`. This lets CI configs set the hint without changing the call site. An explicit `--heap-size-hint` in `julia_args` takes precedence (julia uses the last occurrence).
+  - The `EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` environment variable, when set to a non-empty value (e.g. `6G`), adds `--heap-size-hint=<value>` to the test process' `julia_args`. This lets CI configs set the hint without changing the call site. An explicit `--heap-size-hint` in `julia_args` takes precedence (julia uses the last occurrence).
 
 - `exclude = []` is used to specify string or regexes that are used to filter out some of the files in the list of package includes. The exclusion is done by removing from the list of files all files for which `occursin(needle, filename)` returns `true`, where `needle` is any element of `exclude`.
 
@@ -151,13 +150,14 @@ function generate_package_coverage(
             heap_hint = get(ENV, "EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT", "")
             effective_julia_args =
                 isempty(heap_hint) ? julia_args : ["--heap-size-hint=$heap_hint", julia_args...]
-            if run_test
-                if isnothing(pkg)
-                    Pkg.test(; coverage = true, test_args, julia_args = effective_julia_args)
-                else
-                    Pkg.test(pkg; coverage = true, test_args, julia_args = effective_julia_args)
-                end
-            end
+            # `pkg_name` comes from the (active or named) package's own Project.toml, so we can
+            # always test by name — no need to branch on whether `pkg` was explicitly provided.
+            run_test && Pkg.test(
+                pkg_name;
+                coverage = true,
+                test_args,
+                julia_args = effective_julia_args,
+            )
             # Build the lcov + coverage metrics from the produced data without re-running tests.
             LocalCoverage.generate_coverage(
                 pkg;

--- a/src/ExtendedLocalCoverage.jl
+++ b/src/ExtendedLocalCoverage.jl
@@ -77,7 +77,11 @@ This acts similary to (and based on) the `generate_coverage` function from [Loca
 
 - `run_test = true` this is forwarded to `LocalCoverage.generate_coverage` and determines whether tests are executed. When `false`, test execution step is skipped allowing an easier use in combination with other test packages.
 
-- `test_args = [""]` this is forwarded to `LocalCoverage.generate_coverage` and is there passed on to `Pkg.test`.
+- `test_args = [""]` this is passed on to `Pkg.test` (it becomes `ARGS` in the test process).
+
+- `julia_args = String[]` is a vector of extra command-line flags (strings, like `test_args`) forwarded to the julia process that `Pkg.test` spawns for the test run. The main use case is passing `--heap-size-hint` to bound the test process' GC heap on memory-limited CI runners (where julia otherwise sizes its heap to the host RAM, not the cgroup limit, and can get OOM-killed). For example `julia_args = ["--heap-size-hint=6G"]`. Note `LocalCoverage.generate_coverage` does not forward `julia_args`, which is why this package runs `Pkg.test` directly.
+
+- The `EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` environment variable, when set to a non-empty value (e.g. `6G`), adds `--heap-size-hint=<value>` to the test process' `julia_args`. This lets CI configs set the hint without changing the call site. An explicit `--heap-size-hint` in `julia_args` takes precedence (julia uses the last occurrence).
 
 - `exclude = []` is used to specify string or regexes that are used to filter out some of the files in the list of package includes. The exclusion is done by removing from the list of files all files for which `occursin(needle, filename)` returns `true`, where `needle` is any element of `exclude`.
 
@@ -106,6 +110,7 @@ function generate_package_coverage(
     use_existing_lcov = false,
     run_test = true,
     test_args = [""],
+    julia_args = String[],
     exclude = [],
     html_name = "index.html",
     cobertura_name = "cobertura-coverage.xml",
@@ -136,18 +141,31 @@ function generate_package_coverage(
                 end
                 return true
             end
-            try
-                LocalCoverage.generate_coverage(
-                    pkg;
-                    run_test,
-                    test_args,
-                    folder_list = [],
-                    file_list,
-                )
-            catch e
-                # We used to do this for pretty tables error. Now still kept for a while to test
-                rethrow()
+            # Run the tests ourselves (when requested) so we can forward `julia_args` — e.g.
+            # `--heap-size-hint` — to the julia process `Pkg.test` spawns. LocalCoverage's
+            # `generate_coverage` only forwards `test_args`, not `julia_args`.
+            #
+            # The `EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` env var lets CI set the test-process
+            # heap-size hint without touching the call site. It is prepended, so an explicit
+            # `--heap-size-hint` in `julia_args` still wins (julia takes the last occurrence).
+            heap_hint = get(ENV, "EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT", "")
+            effective_julia_args =
+                isempty(heap_hint) ? julia_args : ["--heap-size-hint=$heap_hint", julia_args...]
+            if run_test
+                if isnothing(pkg)
+                    Pkg.test(; coverage = true, test_args, julia_args = effective_julia_args)
+                else
+                    Pkg.test(pkg; coverage = true, test_args, julia_args = effective_julia_args)
+                end
             end
+            # Build the lcov + coverage metrics from the produced data without re-running tests.
+            LocalCoverage.generate_coverage(
+                pkg;
+                run_test = false,
+                test_args,
+                folder_list = [],
+                file_list,
+            )
         end
     if print_to_stdout
         show(IOContext(stdout, :print_gaps => true), cov)

--- a/test/CoverageTest/test/runtests.jl
+++ b/test/CoverageTest/test/runtests.jl
@@ -1,4 +1,11 @@
 using CoverageTest
 using Test
 
+# When ExtendedLocalCoverage's `julia_args` test passes a (non-empty) file path via
+# `test_args`, record this test process's heap-size hint so the parent can assert that
+# `julia_args = ` --heap-size-hint=… ` ` actually reached the spawned test process.
+if length(ARGS) >= 1 && !isempty(ARGS[1])
+    write(ARGS[1], string(Base.JLOptions().heap_size_hint))
+end
+
 @test hello() == "Hello"

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -153,6 +153,23 @@ end
     end
 end
 
+@testitem "generate_package_coverage with no pkg arg uses the active project" begin
+    import Pkg
+    # Exercises the pkg=nothing path: pkgdir(nothing) -> active project, and Pkg.test by the
+    # active project's own name (no isnothing(pkg) branch).
+    CoverageTest_dir = joinpath(@__DIR__, "CoverageTest")
+    current_proj = dirname(Base.active_project())
+    Pkg.activate(CoverageTest_dir)
+    try
+        cov, xml, html = generate_package_coverage(; print_to_stdout = false)
+        @test isfile(xml)
+        @test isfile(html)
+        rm(dirname(xml); recursive = true, force = true)
+    finally
+        Pkg.activate(current_proj)
+    end
+end
+
 @testitem "highlighted_lines CRLF + multibyte" begin
     # Regression: CRLF line endings with a multibyte char (e.g. π) right before
     # the \r used to throw StringIndexError because the old code stripped the \r

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -77,6 +77,82 @@
     end
 end
 
+@testitem "julia_args reaches the test subprocess" begin
+    import Pkg
+    # `julia_args` must be forwarded to the julia process that `Pkg.test` spawns, so that
+    # flags like `--heap-size-hint` actually take effect (the JULIA_HEAP_SIZE_HINT env var
+    # is ignored; only the CLI flag sets Base.JLOptions().heap_size_hint).
+    CoverageTest_dir = joinpath(@__DIR__, "CoverageTest")
+    hint_file = tempname()
+    current_proj = dirname(Base.active_project())
+    Pkg.activate(CoverageTest_dir)
+    try
+        generate_package_coverage(
+            "CoverageTest";
+            test_args = [hint_file],          # fixture writes heap_size_hint here
+            julia_args = ["--heap-size-hint=2G"],
+            html_name = nothing,
+            cobertura_name = nothing,
+            print_to_stdout = false,
+        )
+        @test isfile(hint_file)
+        @test parse(Int, read(hint_file, String)) == 2 * 2^30  # 2 GiB = 2147483648
+    finally
+        Pkg.activate(current_proj)
+        rm(hint_file; force = true)
+    end
+end
+
+@testitem "EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT env var sets test heap hint" begin
+    import Pkg
+    # CI can set the test-process heap-size hint via an env var, without touching the call site.
+    CoverageTest_dir = joinpath(@__DIR__, "CoverageTest")
+    hint_file = tempname()
+    current_proj = dirname(Base.active_project())
+    Pkg.activate(CoverageTest_dir)
+    try
+        withenv("EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT" => "2G") do
+            generate_package_coverage(
+                "CoverageTest";
+                test_args = [hint_file],   # note: no julia_args passed; the env var must supply the flag
+                html_name = nothing,
+                cobertura_name = nothing,
+                print_to_stdout = false,
+            )
+        end
+        @test parse(Int, read(hint_file, String)) == 2 * 2^30  # 2 GiB = 2147483648
+    finally
+        Pkg.activate(current_proj)
+        rm(hint_file; force = true)
+    end
+end
+
+@testitem "explicit julia_args --heap-size-hint overrides env var" begin
+    import Pkg
+    # When both EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT and an explicit --heap-size-hint in
+    # julia_args are given, the explicit one must win (julia uses the last occurrence).
+    CoverageTest_dir = joinpath(@__DIR__, "CoverageTest")
+    hint_file = tempname()
+    current_proj = dirname(Base.active_project())
+    Pkg.activate(CoverageTest_dir)
+    try
+        withenv("EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT" => "2G") do
+            generate_package_coverage(
+                "CoverageTest";
+                test_args = [hint_file],
+                julia_args = ["--heap-size-hint=4G"],
+                html_name = nothing,
+                cobertura_name = nothing,
+                print_to_stdout = false,
+            )
+        end
+        @test parse(Int, read(hint_file, String)) == 4 * 2^30  # explicit 4 GiB wins over env 2 GiB
+    finally
+        Pkg.activate(current_proj)
+        rm(hint_file; force = true)
+    end
+end
+
 @testitem "highlighted_lines CRLF + multibyte" begin
     # Regression: CRLF line endings with a multibyte char (e.g. π) right before
     # the \r used to throw StringIndexError because the old code stripped the \r


### PR DESCRIPTION
## Summary

Adds a way to pass extra flags — specifically `--heap-size-hint` — to the julia process that `Pkg.test` spawns for the coverage test run. On memory-limited CI runners the coverage run gets OOM-killed because julia sizes its GC heap to the *host* RAM, not the cgroup limit; `--heap-size-hint` bounds it without dropping threads. `LocalCoverage.generate_coverage` forwards only `test_args` (→ runtests `ARGS`), not `julia_args`, so there was previously no way to do this.

## Changes (per commit)
1. **Add Tables as a compat-only weakdep** — declares `Tables` in `[weakdeps]` with a `[compat]` bound to constrain it when pulled in transitively, without adopting it as a direct dependency (also moves `[workspace]` up).
2. **Add `julia_args` + heap-size-hint env var** —
   - new `julia_args::Vector{String}` keyword (mirrors `test_args`), forwarded to the spawned test process. The test run is now driven via `Pkg.test(...; julia_args)` directly, then coverage is processed with `run_test=false`.
   - `EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT` env var: when set, prepends `--heap-size-hint=<value>` to `julia_args`, so CI can configure it without touching the call site. An explicit `--heap-size-hint` in `julia_args` wins.
   - regression tests for all three routes (explicit, env var, explicit-overrides-env), README + docstring updates.
3. **Release 0.2.2** — version bump + CHANGELOG.

## Usage
```julia
generate_package_coverage(; julia_args = ["--heap-size-hint=6G"])
# or, from CI:
#   EXTENDEDLOCALCOVERAGE_HEAP_SIZE_HINT=6G
```

## Verification
TDD: each test was watched fail before implementing. Locally verified that the flag reaches `Base.JLOptions().heap_size_hint` in the spawned test process (2 GiB via explicit and via env var; 4 GiB explicit overriding 2 GiB env). Relying on PR CI (Julia 1 + 1.10) for the full matrix.